### PR TITLE
Display only past and present question in the detail view

### DIFF
--- a/mysite/polls/tests.py
+++ b/mysite/polls/tests.py
@@ -69,13 +69,13 @@ class QuestionIndexViewTests(TestCase):
 
 class QuestionDetailViewTests(TestCase):
 
-    def test_DetailView_should_return_404_not_found_when_question_pub_date_in_the_future(self):
+    def test_should_return_404_for_future_question(self):
         future_question = create_question(question_text='Future question.', days=5)
         url = reverse('polls:detail', args=(future_question.id,))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    def test_DetailView_should_display_question_text_if_question_pub_date_in_the_past(self):
+    def test_should_display_question_text_for_past_question(self):
         past_question = create_question(question_text='Past Question.', days=-5)
         url = reverse('polls:detail', args=(past_question.id,))
         response = self.client.get(url)

--- a/mysite/polls/tests.py
+++ b/mysite/polls/tests.py
@@ -65,3 +65,18 @@ class QuestionIndexViewTests(TestCase):
         self.assertTrue(
             past_question in response.context["latest_question_list"]
         )
+
+
+class QuestionDetailViewTests(TestCase):
+
+    def test_DetailView_should_return_404_not_found_when_question_pub_date_in_the_future(self):
+        future_question = create_question(question_text='Future question.', days=5)
+        url = reverse('polls:detail', args=(future_question.id,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_DetailView_should_display_question_text_if_question_pub_date_in_the_past(self):
+        past_question = create_question(question_text='Past Question.', days=-5)
+        url = reverse('polls:detail', args=(past_question.id,))
+        response = self.client.get(url)
+        self.assertContains(response, past_question.question_text)

--- a/mysite/polls/views.py
+++ b/mysite/polls/views.py
@@ -22,6 +22,9 @@ class DetailView(generic.DetailView):
     model = Question
     template_name = 'polls/detail.html'
 
+    def get_queryset(self):
+        return Question.objects.filter(pub_date__lte=timezone.now())
+
 
 class ResultsView(generic.DetailView):
     model = Question


### PR DESCRIPTION
- Modified the detail view to display requested question only if the question publication date is in past or present.
- And returns a 404 not found for the question with future date.